### PR TITLE
Clean up containers and etcd data on stop

### DIFF
--- a/redis-dyn-amb.service
+++ b/redis-dyn-amb.service
@@ -4,7 +4,6 @@ After=etcd-amb-redis2.service
 [Service]
 ExecStart=/usr/bin/docker run --link etcd-amb-redis2.service:etcd --rm --name %n -p 127.0.0.1::6379 polvi/dynamic-etcd-amb redis-A 6379
 ExecStop=/usr/bin/docker stop -t 3 %n
-ExecStop=/usr/bin/docker rm %n
 
 [X-Fleet]
 X-ConditionMachineOf=etcd-amb-redis2.service


### PR DESCRIPTION
It makes machines re-usable for others or to deploy units again.
